### PR TITLE
Add a static create method on Database class

### DIFF
--- a/src/__tests__/database.spec.ts
+++ b/src/__tests__/database.spec.ts
@@ -1,15 +1,36 @@
 import { Observable } from 'rxjs';
 import { ICollection, IDatabasePersistor } from '../';
-import { Database, DEFAULT_OPTIONS } from '../database';
+import { Database, DatabaseOptions } from '../database';
 import { Collection } from '../collection';
 import { MockCollectionPersistor, MockDatabasePersistor } from '../persistors/__mocks__/persistor.mock';
 import { createCollections } from '../__mocks__/database.mock';
 
 describe( 'Database', () => {
+    describe( 'static defaultOptions', () => {
+        it( 'should have a value', () => {
+            expect(( Database as any ).defaultOptions ).toBeDefined();
+        });
+    });
+
+    describe( 'static configure', () => {
+        it( 'should set the default options', () => {
+            const testOptions: DatabaseOptions = { persistor: new MockDatabasePersistor() };
+            Database.configure( testOptions );
+            expect(( Database as any ).defaultOptions ).toBe( testOptions );
+        });
+    });
+
+    describe( 'static create', () => {
+        it( 'should return a new Database instance', () => {
+            const db = Database.create();
+            expect( db instanceof Database ).toBeTruthy();
+        });
+    });
+
     describe( 'constructor', () => {
         it( 'should create a new instance with default options', () => {
             const database = new Database();
-            expect(( database as any )._options ).toBe( DEFAULT_OPTIONS );
+            expect(( database as any )._options ).toBe(( Database as any ).defaultOptions );
         });
     });
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -12,19 +12,38 @@ export type DatabaseOptions = {
 };
 
 /**
- * DEFAULT_OPTIONS
- * DEFAULT_OPTIONS will be used if database options are not
- * provided when creating a new database.
- */
-export const DEFAULT_OPTIONS = {
-    persistor: new LocalForageDatabasePersistor( 'rxdata' ),
-};
-
-/**
  * Database
  * Database is a collection of collections.
  */
 export class Database implements IDatabase {
+    /**
+     * static defaultOptions
+     * defaultOptions is the DatabaseOptions object which will be used
+     * if an options argument is not provided when creating a database.
+     */
+    protected static defaultOptions: DatabaseOptions = {
+        persistor: new LocalForageDatabasePersistor( 'rxdata' ),
+    };
+
+    /**
+     * static configure
+     * configure sets the default options which will
+     * @param _options: An options object to set as default options.
+     */
+    public static configure( options: DatabaseOptions ) {
+        this.defaultOptions = options;
+    }
+
+    /**
+     * static create
+     * create creates a new Database class with default configurations.
+     * This method can be used as a factory function to create new
+     * Database instances. (eg: with Angular2 AOT compilation)
+     */
+    public static create(): IDatabase {
+        return new Database();
+    }
+
     /**
      * _collections
      * _collections is a map of collections by their names.
@@ -37,7 +56,7 @@ export class Database implements IDatabase {
      *
      * @param _options: An options object to customize the database.
      */
-    constructor( protected _options: DatabaseOptions = DEFAULT_OPTIONS ) {
+    constructor( protected _options: DatabaseOptions = Database.defaultOptions ) {
         this._collections = new Map<string, Collection>();
     }
 


### PR DESCRIPTION
It'll be more convenient to use with Angular apps with AOT compilation.

```ts
{
  providers: [
    { provide: Database, useFactory: Database.create }
  ]
}
```

Also allows the user to set default options for databases.